### PR TITLE
refactor AngelVelocity2Angel function and add dead zone for angular vel 

### DIFF
--- a/hunter_base/include/hunter_base/hunter_messenger.hpp
+++ b/hunter_base/include/hunter_base/hunter_messenger.hpp
@@ -474,33 +474,15 @@ class HunterMessenger {
   
   double AngelVelocity2Angel(geometry_msgs::msg::Twist msg,double &radius)
   {
-    double linear = fabs(msg.linear.x);
-    double angular = fabs(msg.angular.z);
-    if(angular == 0)
-    {
-      return 0.0;
-    }
-
-    radius = linear / angular;
-
-    int k = msg.angular.z / fabs(msg.angular.z);
-    if ((radius-l)<0 )
-    {
-      return  k*max_steer_angle;
-    }
-
-    double phi_i;
-    phi_i = atan(l/(radius-w/2));
-    if(msg.linear.x<0)
-      phi_i *= -1.0;
-    return k*phi_i;
+    return AngelVelocity2Angel(msg.linear.x, msg.angular.z, radius);
   }
 
   double AngelVelocity2Angel(double& linear_vel, double& angular_vel, double &radius)
   {
     double linear = fabs(linear_vel);
     double angular = fabs(angular_vel);
-    if(angular == 0)
+
+    if(angular < 0.001) // adding dead zone
     {
       return 0.0;
     }

--- a/hunter_base/launch/hunter_base.launch.py
+++ b/hunter_base/launch/hunter_base.launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
     sim_control_rate_arg = DeclareLaunchArgument('control_rate', default_value='50',
                                                  description='Simulation control loop update rate')
 
-    enable_pd_regulator = LaunchConfiguration('enable_pd_regulator', default='True')
+    enable_pd_regulator = LaunchConfiguration('enable_pd_regulator', default='False')
     
     kp_v = LaunchConfiguration('kp_v', default='40.0')
     kd_v = LaunchConfiguration('kd_v', default='0.1') 


### PR DESCRIPTION
…elocity; update default regulator setting in launch file

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
During testing I have found that when sending 0.0 vel cmd, the steering wheels where fluctuating, the main issue of that was the PD regulator that was added by Geesara and when comparing the angular angle it was casting it to int!! so I have fix that and added dead zone to the angular vel


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes._

## [optional] Are there any post deployment tasks we need to perform?
